### PR TITLE
Add ignore_paths config option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Added `ignore_paths` configuration option to completely skip files from validation. Supports glob patterns (e.g., `vendor/**`) and exact paths (e.g., `README.md`).
+
 ## [0.4.0] - 2026-03-10
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -116,9 +116,15 @@ By default, the validator looks for `./frontmatter-validator.yaml` in the curren
 
 ### Configuration file format
 
-The configuration file uses YAML format with two main sections. A JSON Schema is provided at `frontmatter-validator.schema.json` for IDE validation and autocompletion support.
+The configuration file uses YAML format with three main sections. A JSON Schema is provided at `frontmatter-validator.schema.json` for IDE validation and autocompletion support.
 
 ```yaml
+# Files to skip entirely
+ignore_paths:
+  - "README.md"
+  - "CONTRIBUTING.md"
+  - "vendor/**"
+
 # Default rules applied to all files
 default_rules:
   enabled_checks:
@@ -133,7 +139,7 @@ directory_overrides:
     disabled_checks:
       - NO_DESCRIPTION
       - NO_OWNER
-  
+
   - path: "src/content/changes/**"
     disabled_checks:
       - NO_USER_QUESTIONS
@@ -141,8 +147,11 @@ directory_overrides:
 
 ### Configuration sections
 
+#### `ignore_paths`
+List of file path patterns to completely skip during validation. Files matching any of these patterns will not be validated at all. Supports the same glob patterns as `directory_overrides`.
+
 #### `default_rules`
-Defines the baseline validation rules that apply to all files unless overridden.
+Defines the baseline validation rules that apply to all non-ignored files unless overridden.
 
 - `enabled_checks`: List of validation check IDs that should be enabled by default
 

--- a/frontmatter-validator.schema.json
+++ b/frontmatter-validator.schema.json
@@ -31,6 +31,18 @@
       },
       "additionalProperties": false
     },
+    "ignore_paths": {
+      "type": "array",
+      "title": "Ignore Paths",
+      "description": "List of file path patterns to completely skip during validation. Supports glob patterns like 'vendor/**' or exact paths like 'README.md'.",
+      "items": {
+        "type": "string"
+      },
+      "uniqueItems": true,
+      "examples": [
+        ["README.md", "CONTRIBUTING.md", "vendor/**"]
+      ]
+    },
     "directory_overrides": {
       "type": "array",
       "title": "Directory Overrides",

--- a/pkg/config/manager.go
+++ b/pkg/config/manager.go
@@ -210,6 +210,21 @@ func (m *Manager) getDefaultConfig() *Config {
 	}
 }
 
+// IsPathIgnored checks if a file path should be completely ignored based on ignore_paths configuration
+func (m *Manager) IsPathIgnored(filePath string) bool {
+	if m.config == nil {
+		return false
+	}
+
+	for _, pattern := range m.config.IgnorePaths {
+		if m.pathMatches(filePath, pattern) {
+			return true
+		}
+	}
+
+	return false
+}
+
 // GetConfig returns the loaded configuration
 func (m *Manager) GetConfig() *Config {
 	return m.config

--- a/pkg/config/manager_test.go
+++ b/pkg/config/manager_test.go
@@ -223,6 +223,72 @@ directory_overrides:
 	}
 }
 
+func TestManager_IsPathIgnored(t *testing.T) {
+	tests := []struct {
+		name        string
+		ignorePaths []string
+		filePath    string
+		want        bool
+	}{
+		{
+			name:        "exact match ignored",
+			ignorePaths: []string{"README.md"},
+			filePath:    "README.md",
+			want:        true,
+		},
+		{
+			name:        "exact match not ignored",
+			ignorePaths: []string{"README.md"},
+			filePath:    "src/content/docs/example.md",
+			want:        false,
+		},
+		{
+			name:        "glob pattern ignored",
+			ignorePaths: []string{"vendor/**"},
+			filePath:    "vendor/some/lib/file.md",
+			want:        true,
+		},
+		{
+			name:        "glob pattern not ignored",
+			ignorePaths: []string{"vendor/**"},
+			filePath:    "src/content/docs/example.md",
+			want:        false,
+		},
+		{
+			name:        "multiple patterns",
+			ignorePaths: []string{"README.md", "CONTRIBUTING.md", ".claude/**"},
+			filePath:    ".claude/skills/test/SKILL.md",
+			want:        true,
+		},
+		{
+			name:        "empty ignore paths",
+			ignorePaths: nil,
+			filePath:    "README.md",
+			want:        false,
+		},
+		{
+			name:        "leading dot-slash normalized",
+			ignorePaths: []string{"README.md"},
+			filePath:    "./README.md",
+			want:        true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			m := &Manager{
+				config: &Config{
+					IgnorePaths: tt.ignorePaths,
+				},
+			}
+			got := m.IsPathIgnored(tt.filePath)
+			if got != tt.want {
+				t.Errorf("IsPathIgnored(%q) = %v, want %v", tt.filePath, got, tt.want)
+			}
+		})
+	}
+}
+
 func TestNewManager_NoConfigFile(t *testing.T) {
 	// Test with non-existent config file
 	manager, err := NewManager("/non/existent/config.yaml")

--- a/pkg/config/types.go
+++ b/pkg/config/types.go
@@ -4,6 +4,7 @@ package config
 type Config struct {
 	DefaultRules       RuleSet             `yaml:"default_rules"`
 	DirectoryOverrides []DirectoryOverride `yaml:"directory_overrides"`
+	IgnorePaths        []string            `yaml:"ignore_paths,omitempty"`
 }
 
 // RuleSet defines which validation checks are enabled or disabled

--- a/pkg/validator/validator.go
+++ b/pkg/validator/validator.go
@@ -19,6 +19,7 @@ type Validator struct {
 // ConfigManager interface for configuration management
 type ConfigManager interface {
 	GetEnabledChecksForPath(filePath string) []string
+	IsPathIgnored(filePath string) bool
 }
 
 // New creates a new Validator instance with default configuration
@@ -53,6 +54,10 @@ func createDefaultConfigManager() (ConfigManager, error) {
 
 // defaultConfigManager provides default configuration when no config file is used
 type defaultConfigManager struct{}
+
+func (dcm *defaultConfigManager) IsPathIgnored(filePath string) bool {
+	return false
+}
 
 func (dcm *defaultConfigManager) GetEnabledChecksForPath(filePath string) []string {
 	// Return all checks enabled by default - this matches the old behavior
@@ -110,6 +115,11 @@ func (v *Validator) ValidateFile(content, filePath string) ValidationResult {
 	result := ValidationResult{
 		NumFrontMatterLines: 0,
 		Checks:              []CheckResult{},
+	}
+
+	// Check if path is ignored
+	if v.configManager != nil && v.configManager.IsPathIgnored(filePath) {
+		return result
 	}
 
 	// Check for trailing newline

--- a/pkg/validator/validator_test.go
+++ b/pkg/validator/validator_test.go
@@ -329,6 +329,7 @@ func getCheckIDs(checks []CheckResult) []string {
 type mockConfigManager struct {
 	enabledChecks map[string][]string // path pattern -> enabled check IDs
 	defaultChecks []string
+	ignoredPaths  map[string]bool
 }
 
 func (m *mockConfigManager) GetEnabledChecksForPath(filePath string) []string {
@@ -336,6 +337,33 @@ func (m *mockConfigManager) GetEnabledChecksForPath(filePath string) []string {
 		return checks
 	}
 	return m.defaultChecks
+}
+
+func (m *mockConfigManager) IsPathIgnored(filePath string) bool {
+	if m.ignoredPaths == nil {
+		return false
+	}
+	return m.ignoredPaths[filePath]
+}
+
+func TestValidateFile_IgnoredPath(t *testing.T) {
+	cm := &mockConfigManager{
+		defaultChecks: []string{"NO_FRONT_MATTER", "NO_TRAILING_NEWLINE"},
+		ignoredPaths:  map[string]bool{"README.md": true},
+	}
+	v := NewWithConfig(cm)
+
+	// File without frontmatter - would normally trigger NO_FRONT_MATTER
+	result := v.ValidateFile("# Just a readme\n", "README.md")
+	if len(result.Checks) != 0 {
+		t.Errorf("Expected no checks for ignored path, got %d: %v", len(result.Checks), result.Checks)
+	}
+
+	// Same content on a non-ignored path should trigger checks
+	result = v.ValidateFile("# Just a readme\n", "src/content/docs/example.md")
+	if len(result.Checks) == 0 {
+		t.Error("Expected checks for non-ignored path, got none")
+	}
 }
 
 func TestValidateFile_ConfigDisablesNoTitle(t *testing.T) {


### PR DESCRIPTION
Adds a `ignore_paths` config option that makes it a lot easier to ignore certain files and directories.

### Do the docs need to be updated?

Done

### Should this change be mentioned in the release notes?

- [x] CHANGELOG.md has been updated (if it exists)
