### PR TITLE
feat(ci): release darwin and windows binaries

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,7 +9,7 @@ workflows:
       - architect/go-build:
           context: architect
           name: go-build
-          binary: template
+          binary: frontmatter-validator
           architectures: "linux/amd64,linux/arm64,darwin/amd64,darwin/arm64,windows/amd64,windows/arm64"
           filters:
             # Trigger job also on git tag.

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -20,6 +20,7 @@ workflows:
           name: push-to-registries
           requires:
             - go-build
+          platforms: "linux/amd64,linux/arm64"
           registries-data: |-
             public gsoci.azurecr.io ACR_GSOCI_USERNAME ACR_GSOCI_PASSWORD true
           filters:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -32,6 +32,7 @@ workflows:
                 - main
                 - master
       - architect/upload-release-assets:
+          binary: frontmatter-validator
           context: architect
           requires:
             - go-build

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,6 +10,7 @@ workflows:
           context: architect
           name: go-build
           binary: template
+          architectures: "linux/amd64,linux/arm64,darwin/amd64,darwin/arm64,windows/amd64,windows/arm64"
           filters:
             # Trigger job also on git tag.
             tags:
@@ -19,6 +20,7 @@ workflows:
           name: push-to-registries
           requires:
             - go-build
+          platforms: "linux/amd64"
           registries-data: |-
             public gsoci.azurecr.io ACR_GSOCI_USERNAME ACR_GSOCI_PASSWORD true
           filters:
@@ -29,3 +31,12 @@ workflows:
               ignore:
                 - main
                 - master
+      - architect/upload-release-assets:
+          context: architect
+          requires:
+            - go-build
+          filters:
+            branches:
+              ignore: /.*/
+            tags:
+              only: /^v.*/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -20,7 +20,6 @@ workflows:
           name: push-to-registries
           requires:
             - go-build
-          platforms: "linux/amd64,linux/arm64"
           registries-data: |-
             public gsoci.azurecr.io ACR_GSOCI_USERNAME ACR_GSOCI_PASSWORD true
           filters:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -20,7 +20,7 @@ workflows:
           name: push-to-registries
           requires:
             - go-build
-          platforms: "linux/amd64"
+          platforms: "linux/amd64,linux/arm64"
           registries-data: |-
             public gsoci.azurecr.io ACR_GSOCI_USERNAME ACR_GSOCI_PASSWORD true
           filters:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Release binaries now include darwin/amd64, darwin/arm64, windows/amd64, and windows/arm64 alongside the existing linux targets. Windows binaries are named `frontmatter-validator-windows-<arch>.exe`.
+
 ## [0.5.0] - 2026-03-10
 
 ### Added

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,17 +1,8 @@
-FROM --platform=$BUILDPLATFORM gsoci.azurecr.io/giantswarm/golang:1.26.4-alpine3.22 AS builder
+FROM --platform=$TARGETPLATFORM gsoci.azurecr.io/giantswarm/alpine:3.23.4
 
-ARG TARGETOS TARGETARCH
+ARG TARGETARCH
 
-WORKDIR /usr/src/app
-
-COPY go.mod go.sum ./
-RUN go mod download
-
-COPY . .
-RUN GOOS=$TARGETOS GOARCH=$TARGETARCH go build -v .
-
-FROM gsoci.azurecr.io/giantswarm/alpine:3.23.4
-COPY --from=builder /usr/src/app/frontmatter-validator /usr/local/bin/frontmatter-validator
+COPY frontmatter-validator-linux-${TARGETARCH} /usr/local/bin/frontmatter-validator
 RUN chmod +x /usr/local/bin/frontmatter-validator
 
 WORKDIR /app

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=$TARGETPLATFORM gsoci.azurecr.io/giantswarm/alpine:3.23.4
+FROM gsoci.azurecr.io/giantswarm/alpine:3.23.4
 
 ARG TARGETARCH
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,6 @@
-FROM gsoci.azurecr.io/giantswarm/golang:1.26.4-alpine3.22 AS builder
+FROM --platform=$BUILDPLATFORM gsoci.azurecr.io/giantswarm/golang:1.26.4-alpine3.22 AS builder
+
+ARG TARGETOS TARGETARCH
 
 WORKDIR /usr/src/app
 
@@ -6,7 +8,7 @@ COPY go.mod go.sum ./
 RUN go mod download
 
 COPY . .
-RUN go build -v .
+RUN GOOS=$TARGETOS GOARCH=$TARGETARCH go build -v .
 
 FROM gsoci.azurecr.io/giantswarm/alpine:3.23.4
 COPY --from=builder /usr/src/app/frontmatter-validator /usr/local/bin/frontmatter-validator


### PR DESCRIPTION
## What

- `go-build`: adds `darwin/amd64`, `darwin/arm64`, `windows/amd64`, `windows/arm64` to the `architectures` list.
- `upload-release-assets`: uploads signed bare binaries and cosign `.bundle` files to the GitHub Release on tags.
- Bumps architect orb to 9.1.0, which names Windows binaries `<binary>-windows-<arch>.exe` and adds cosign keyless signing and SBOM attestations.
- Dockerfile: drops the builder stage entirely. `push-to-registries` attaches the `go-build` workspace, so the image just COPYs the pre-built `frontmatter-validator-linux-${TARGETARCH}` binary. `platforms` is removed from `push-to-registries` and auto-derived from the `.platforms` file `go-build` writes.

Same pattern as giantswarm/muster#796.