### PR TITLE
fix(deps): bump golang.org/x/text to v0.41.0 (CVE-2026-56852)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/giantswarm/frontmatter-validator
 
-go 1.23.0
+go 1.25.0
 
 require (
 	github.com/spf13/afero v1.15.0
@@ -11,5 +11,5 @@ require (
 require (
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/spf13/pflag v1.0.9 // indirect
-	golang.org/x/text v0.28.0 // indirect
+	golang.org/x/text v0.41.0 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -11,6 +11,6 @@ github.com/spf13/pflag v1.0.9/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An
 go.yaml.in/yaml/v3 v3.0.4/go.mod h1:DhzuOOF2ATzADvBadXxruRBLzYTpT36CKvDb3+aBEFg=
 go.yaml.in/yaml/v4 v4.0.0-rc.6 h1:1h7H1ohdUh93/FyE4YaDa1Zh64K6VVbjF4K6WUxMtH4=
 go.yaml.in/yaml/v4 v4.0.0-rc.6/go.mod h1:aZqd9kCMsGL7AuUv/m/PvWLdg5sjJsZ4oHDEnfPPfY0=
-golang.org/x/text v0.28.0 h1:rhazDwis8INMIwQ4tpjLDzUhx6RlXqZNPEM0huQojng=
-golang.org/x/text v0.28.0/go.mod h1:U8nCwOR8jO/marOQ0QbDiOngZVEBB7MAiitBuMjXiNU=
+golang.org/x/text v0.41.0 h1:vz/seA0lnX87Othu2f/0L24RcgrXD9/YFTSuGjj3rH8=
+golang.org/x/text v0.41.0/go.mod h1:jvf1O8ajNzZqhSrQBPbutR/EB83Cc0CFrezNQIwbb5M=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=


### PR DESCRIPTION
Bumps the transitive `golang.org/x/text` to the patched `v0.41.0`.

`CVE-2026-56852` / `GO-2026-5970` is an infinite loop in `golang.org/x/text/unicode/norm` on invalid UTF-8 input. `nancy` audits the whole module graph and gates the shared `go-build` job, so the unpatched transitive dependency fails CI on **every** open PR in this repo regardless of content.

`go get golang.org/x/text@v0.41.0 && go mod tidy` (twice, for idempotency); `go build -mod=readonly ./...` verified green locally.

Part of giantswarm/github#5786 — the same bump across 12 repos.